### PR TITLE
Increase zIndex to fix issue with Bootstrap modal

### DIFF
--- a/jscolor.js
+++ b/jscolor.js
@@ -1024,7 +1024,7 @@ var jsc = {
 		this.pointerBorderColor = '#FFFFFF'; // px
         this.pointerBorderWidth = 1; // px
         this.pointerThickness = 2; // px
-		this.zIndex = 1000;
+		this.zIndex = 9999;
 		this.container = null; // where to append the color picker (BODY element by default)
 
 


### PR DESCRIPTION
I've increased the zIndex property in order to play well with other layers which also has zIndex like Bootstrap Modal which has 1050. I think 9999 should be good enough.
