### PR TITLE
Add a class to the style element when dark contrast is enabled

### DIFF
--- a/jscolor.js
+++ b/jscolor.js
@@ -1106,7 +1106,14 @@ var jsc = {
 				if (this.styleElement) {
 					this.styleElement.style.backgroundImage = 'none';
 					this.styleElement.style.backgroundColor = '#' + this.toString();
-					this.styleElement.style.color = this.isLight() ? '#000' : '#FFF';
+
+					if (this.isLight()) {
+						this.styleElement.style.color = '#000';
+						jsc.unsetClass(this.styleElement, 'dark');
+					} else {
+						this.styleElement.style.color = '#FFF';
+						jsc.setClass(this.styleElement, 'dark');
+					}
 				}
 			}
 			if (!(flags & jsc.leavePad) && isPickerOwner()) {


### PR DESCRIPTION
This allows us to further style descendants of this element taking into
account the reversed contrast.

In my case I was setting the background colour on a div that contained links and other elements. Having a class set on the `styleElement` meant that I could target these descendant elements and change their colour when the contrast was defined as ‘dark’.
