### PR TITLE
enterpriselicense_link_broken

### DIFF
--- a/enterpriselicense_link_broken
+++ b/enterpriselicense_link_broken
@@ -1,0 +1,2 @@
+Trying to purchase enterprise license, but this link isn't working: http://jscolor.com/license/?type=org
+(Please advise what to do.)


### PR DESCRIPTION
Trying to purchase enterprise license, but this link isn't working: http://jscolor.com/license/?type=org
(Please advise what to do.)