### PR TITLE
Add support for initing jscolor after domcontentloaded has fired

### DIFF
--- a/jscolor.js
+++ b/jscolor.js
@@ -52,7 +52,11 @@ var jsc = {
 
 	register : function () {
 		if (typeof window !== 'undefined' && window.document) {
-			window.document.addEventListener('DOMContentLoaded', jsc.pub.init, false);
+			if (window.document.readyState !== 'loading') {
+		    		jsc.pub.init();
+			} else {
+		    		window.document.addEventListener('DOMContentLoaded', jsc.pub.init, false);
+			}
 		}
 	},
 


### PR DESCRIPTION
I am importing this package into a userscript, and have come across a edgecase where in some cases the dom has already loaded whilst my userscript is still initalizing

This adds a check to see if the window has already loaded, and if it has call init, otherwise add the event listener